### PR TITLE
adjusted positions of tooltips

### DIFF
--- a/src/components/ZoneProgress.vue
+++ b/src/components/ZoneProgress.vue
@@ -814,9 +814,8 @@ function formatNumber(num, f = false) {
 .ascend-tooltip {
   display: none;
   position: absolute;
-  top: -100%;
-  left: 100%;
-  transform: translateY(-50%);
+  top: calc(100% + 30px);
+  left: -50%;
   width: 230px;
   background: #1e1e1e;
   color: #fff;
@@ -864,9 +863,8 @@ function formatNumber(num, f = false) {
 .rebirth-tooltip, .abyss-tooltip, .inf-tooltip, .soul-tooltip, .singularity-tooltip {
   display: none;
   position: absolute;
-  
-  left: 100%;
-  transform: translateY(-50%);
+  top: calc(100% + 30px);
+  left: -50%;
   width: 230px;
   background: #1e1e1e;
   color: #fff;
@@ -883,14 +881,14 @@ function formatNumber(num, f = false) {
 }
 
 .abyss-shadow {
-  top: 180%;
+  top: calc(100% + 30px);
   box-shadow: 0 0 10px rgba(225, 0, 255, 0.8);
   overflow-y: auto;
   max-height: 300px;
 }
 
 .inf-shadow {
-  top: 180%;
+  top: calc(100% + 30px);
   box-shadow: 0 0 10px rgb(238, 255, 0);
   max-height: 300px;
   overflow: auto;

--- a/src/components/ZoneProgress.vue
+++ b/src/components/ZoneProgress.vue
@@ -895,7 +895,7 @@ function formatNumber(num, f = false) {
 }
 
 .singularity-shadow {
-  top: 180%;
+  top: calc(100% + 30px);
   box-shadow: 0 0 12px 4px #66ffcc;
   max-height: 300px;
   overflow: auto;


### PR DESCRIPTION
Adjusting positions of the tooltips for resets so they no longer cover the other reset buttons

Example of new positioning:
![image](https://github.com/user-attachments/assets/224fe2f0-75bc-4315-bc70-9829dee8f616)